### PR TITLE
Server's unicode support & better environment 

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 project(fasttyping_server)
 
 set(CMAKE_CXX_STANDARD 17)
-find_package(Boost 1.71 REQUIRED system log)
+find_package(Boost 1.71 REQUIRED system log locale)
 find_package(nlohmann_json 3.7.3 REQUIRED)
 find_package(Threads)
 include(FetchContent)
@@ -14,7 +14,6 @@ FetchContent_Declare(
 set(PQXX_LIBRARIES pqxx_static)
 
 FetchContent_MakeAvailable(libpqxx)
-
 
 include_directories(include ../common/include)
 add_executable(server src/database.cpp src/main.cpp src/server.cpp src/game.cpp include/user.h)

--- a/server/include/game.h
+++ b/server/include/game.h
@@ -26,7 +26,8 @@ public:
 
     bool hasUser(int uid);
 
-    json addNewChar(int uid, char c);
+    // character is a string due to UTF-8
+    json addNewChar(int uid, const std::string &c);
     json backspace(int uid);
     json check(int uid);
     json getNewLine(int uid);
@@ -44,7 +45,7 @@ private:
     std::unique_ptr<FastTyping::Logic::AbstractDictionary> dictionary;
 
     struct AdditionalUserInfo {
-        std::string currentBuffer;
+        std::vector<std::string> currentBuffer;
         int currentWord = 0;
         int lineNumber = 0;
     };

--- a/server/src/database.cpp
+++ b/server/src/database.cpp
@@ -1,8 +1,11 @@
 #include "database.h"
 #include <algorithm>
+#include <cstdlib>
+#include <string>
 
 namespace FastTyping::Server {
-Database::Database() : connect("dbname = fast_typing") {
+Database::Database()
+    : connect("dbname = " + std::string(std::getenv("FASTTYPING_DB"))) {
     try {
         if (connect.is_open()) {
             std::cerr << "Opened database successfully: " << connect.dbname()

--- a/server/src/game.cpp
+++ b/server/src/game.cpp
@@ -1,4 +1,6 @@
 #include "game.h"
+#include <algorithm>
+#include <boost/locale.hpp>
 #include <boost/log/trivial.hpp>
 #include <iostream>
 #include "constGame.h"
@@ -17,13 +19,20 @@ json Game::checkUnsafe(int uid) {
     json result;
     std::string rightWord =
         dictionary->getWord(additionalInfo[uid].currentWord);
-    std::string &word = additionalInfo[uid].currentBuffer;
-    BOOST_LOG_TRIVIAL(debug)
-        << "Buffer of user " << uid << " is \"" << word << "\"\n";
+    auto &word = additionalInfo[uid].currentBuffer;
+    BOOST_LOG_TRIVIAL(debug) << "Buffer of user " << uid << " is \"";
+    for (auto chr : word) {
+        BOOST_LOG_TRIVIAL(debug) << chr;
+    }
+    BOOST_LOG_TRIVIAL(debug) << "\"";
+    auto concatenatedBuffer =
+        std::accumulate(word.begin(), word.end(), std::string());
+
     result["header"] = {{"type", "checkResult"}};
     result["body"] = {
-        {"isFullCorrect", parser->isFullCorrect(word, rightWord)},
-        {"isPrefixCorrect", parser->isPrefixCorrect(word, rightWord)},
+        {"isFullCorrect", parser->isFullCorrect(concatenatedBuffer, rightWord)},
+        {"isPrefixCorrect",
+         parser->isPrefixCorrect(concatenatedBuffer, rightWord)},
         {"isEnd", false},
     };
     return result;
@@ -34,9 +43,9 @@ json Game::check(int uid) {
     return checkUnsafe(uid);
 }
 
-json Game::addNewChar(int uid, char c) {
+json Game::addNewChar(int uid, const std::string &c) {
     std::unique_lock l{mutex};
-    additionalInfo[uid].currentBuffer += c;
+    additionalInfo[uid].currentBuffer.push_back(c);
     auto checkResult = checkUnsafe(uid);
     if (checkResult["body"]["isFullCorrect"] == true) {
         auto &info = additionalInfo[uid];
@@ -49,7 +58,7 @@ json Game::addNewChar(int uid, char c) {
 }
 json Game::backspace(int uid) {
     std::unique_lock l{mutex};
-    std::string &word = additionalInfo[uid].currentBuffer;
+    auto &word = additionalInfo[uid].currentBuffer;
     if (word.empty()) {
         return {{"header", {{"type", "emptyBufferError"}}},
                 {"body", {{"text", "can't use backspace with empty buffer"}}}};
@@ -82,8 +91,9 @@ json Game::getStateOfUsers() {
 
 std::shared_ptr<Game> MapGameStorage::get(int id, json &errors) {
     std::unique_lock l{map_mutex};
-    if (auto it = games.find(id); it != games.end())
+    if (auto it = games.find(id); it != games.end()) {
         return it->second;
+    }
     errors = {{"header", {{"type", "wrongIdError"}}},
               {"body", {{"text", "Can't find game with specific id"}}}};
     return nullptr;
@@ -97,10 +107,13 @@ json MapGameStorage::createGame(const json &body) {
         return {{"header", {{"type", "wrongFormatError"}}},
                 {"body", {{"text", "Can't find words"}}}};
     }
-    std::shared_ptr<Game> game = std::make_shared<Game>(
-        std::make_unique<Logic::SimpleParser>(),
-        std::make_unique<Logic::Dictionary>(
-            body["words"].get<std::vector<std::string>>()));
+    auto words = body["words"].get<std::vector<std::string>>();
+    std::for_each(words.begin(), words.end(), [&](std::string &word) {
+        word = boost::locale::normalize(word, boost::locale::norm_nfkc);
+    });
+    std::shared_ptr<Game> game =
+        std::make_shared<Game>(std::make_unique<Logic::SimpleParser>(),
+                               std::make_unique<Logic::Dictionary>(words));
     {
         std::unique_lock l{map_mutex};
         games[game->getId()] = game;

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -1,6 +1,11 @@
+#include <cstdlib>
 #include <iostream>
 #include "server.h"
 
 int main() {
+    if (!std::getenv("FASTTYPING_DB")) {  // check before database creation
+        std::cerr << "specify env variable FASTTYPING_DB\n";
+        std::abort();
+    }
     FastTyping::Server::Server::getInstance().polling();
 }

--- a/server/src/server.cpp
+++ b/server/src/server.cpp
@@ -1,4 +1,5 @@
 #include "server.h"
+#include <boost/locale.hpp>
 #include <boost/log/trivial.hpp>
 #include <iostream>
 #include <memory>
@@ -11,6 +12,9 @@ Server::Server()
     : acceptor(ioContext, tcp::endpoint(tcp::v4(), PORT)),
       userStorage(new Database),
       gameStorage(new MapGameStorage) {
+    boost::locale::generator gen;
+    std::locale::global(gen(""));
+
     std::cout << "Listening at " << acceptor.local_endpoint() << std::endl;
     commonQueriesMap["echo"] = [&](const json &body, User &user) -> json {
         return body;
@@ -98,14 +102,23 @@ Server::Server()
             return {{"header", {{"type", "notInGameError"}}},
                     {"body", {{"text", "not in game"}}}};
         }
-        if (!body.contains("char") || !body["char"].is_string() ||
-            body["char"].get<std::string>().size() != 1) {
+        if (!body.contains("char") || !body["char"].is_string()) {
             return {{"header", {{"type", "wrongFormatError"}}},
                     {"body", {{"text", "can't find word to check"}}}};
         }
 
-        auto result = user.getGame()->addNewChar(
-            user.getId(), body["char"].get<std::string>()[0]);
+        auto normalized = boost::locale::normalize(
+            body["char"].get<std::string>(), boost::locale::norm_nfkc);
+
+        boost::locale::boundary::ssegment_index index(
+            boost::locale::boundary::character, normalized.begin(),
+            normalized.end());
+        if (std::distance(index.begin(), index.end()) != 1) {
+            return {{"header", {{"type", "notSingleChar"}}},
+                    {"body", {{"text", "can't find word to check"}}}};
+        }
+
+        auto result = user.getGame()->addNewChar(user.getId(), normalized);
         return result;
     };
     commonQueriesMap["backspace"] = [&](const json &body, User &user) -> json {


### PR DESCRIPTION
Сделал полную поддержку юникода на сервере в разделе игры. Теперь все символы вводятся как отдельные кластеры, которые можно спокойно удалять. Также при создании игры слова проходят NFKC нормализацию, так же как и добавляемые символы, что позволяет нам контролировать и верифицировать ввод.

Также немного изменено окружение: теперь название датабазы -- переменная окружения, для более удобного тестирования (можно дропнуть всегда).

Fixes #36 and fixes #22 